### PR TITLE
Added contract settings and deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,12 @@ String ethUrl = "ws://10.0.2.2:8545";
 Wallet wallet = new Wallet(appDir +"/wallet", "password");
 // We are alice in this example and this is our on-chain secret key holding the ETH.
 Address alice = wallet.importAccount("0x69cb97043e56883d66627e8f7a828877a56022d0fb05ae6197e6e16fb56282d0");
+// Using null as either Adjudicator or Assetholder tells the Client to deploy the contracts,
+// in this case we already deployed them.
+Address adjudicator = new Address("0xDc4A7e107aD6dBDA1870df34d70B51796BBd1335");
+Address assetholder = new Address("0xb051EAD0C6CC2f568166F8fEC4f07511B88678bA");
 // Listen on 127.0.0.1:5750 for channel Proposals.
-Config cfg = new Config("Alice ", alice, dbPath, ethUrl, "127.0.0.1", 5750);
+Config cfg = new Config("Alice ", alice, adjudicator, assetholder, dbPath, ethUrl, "127.0.0.1", 5750);
 // Create a client, currently skipping the ProposalHandler.
 Client client = new Client(cfg, wallet);
 // PerunId (currently an Address) of the peer that we want to open a channel with.

--- a/client_proposal.go
+++ b/client_proposal.go
@@ -42,7 +42,7 @@ func (c *Client) ProposeChannel(
 	initialBals *BigInts,
 ) (*PaymentChannel, error) {
 	alloc := &channel.Allocation{
-		Assets:   []channel.Asset{(*ethwallet.Address)(&assetAddr)},
+		Assets:   []channel.Asset{(*ethwallet.Address)(&c.cfg.AssetHolder.addr)},
 		Balances: [][]channel.Bal{initialBals.values},
 	}
 	prop := &client.ChannelProposal{

--- a/config.go
+++ b/config.go
@@ -18,28 +18,28 @@ import (
 // Config complete configuration needed to operate the Client.
 type Config struct {
 	// Name to be used in state channels.
-	Alias        string
-	Address      *Address // OnChain address also called PerunID.
-	DatabasePath string   // Path to the database file.
-	ETHNodeURL   string   // URL of the ETH node. Example: ws://127.0.0.1:8545
-	IP           string   // Ip to listen on.
-	Port         uint16   // Port to listen on.
+	Alias   string
+	Address *Address // OnChain address and PerunID.
+	// On-chain addresses of the Adjudicator and AssetHolder Contract.
+	// In case any of them is nil, the Client will deploy the contract in its
+	// NewClient constructor.
+	Adjudicator, AssetHolder *Address
+	DatabasePath             string // Path to the database file.
+	ETHNodeURL               string // URL of the ETH node. Example: ws://127.0.0.1:8545
+	IP                       string // Ip to listen on.
+	Port                     uint16 // Port to listen on.
 }
-
-// assetAddr Address of the Asset to be used.
-var assetAddr = common.HexToAddress("0xb051EAD0C6CC2f568166F8fEC4f07511B88678bA")
-
-// adjudicatorAdr Address of the Adjudicator to be used.
-var adjudicatorAdr = common.HexToAddress("0xDc4A7e107aD6dBDA1870df34d70B51796BBd1335")
 
 // Random address
 var appDef = common.HexToAddress("0x0583849a3C5F37aEfAb8cCcA303f9229AdF5A32a")
 
 // NewConfig creates a new configuration
-func NewConfig(alias string, address *Address, databasePath, ETHNodeURL, ip string, port int) *Config {
+func NewConfig(alias string, address, adjudicator, assetHolder *Address, databasePath, ETHNodeURL, ip string, port int) *Config {
 	return &Config{
 		Alias:        alias,
 		Address:      address,
+		Adjudicator:  adjudicator,
+		AssetHolder:  assetHolder,
 		DatabasePath: databasePath,
 		ETHNodeURL:   ETHNodeURL,
 		IP:           ip,


### PR DESCRIPTION
Contracts can be set in the `Config` now, using `nil` tells the `NewClient` method to deploy them.  
Currently `NewClient` modifies the passed `Config` argument, that is probably not optimal.